### PR TITLE
임인호 : BOJ 9461 파도반 수열

### DIFF
--- a/Inho/BOJ/Week1/Boj9461_파도반수열.java
+++ b/Inho/BOJ/Week1/Boj9461_파도반수열.java
@@ -1,0 +1,26 @@
+package week1;
+import java.io.*;
+import java.util.*;
+
+public class Boj9461_파도반수열 {
+
+	public static void main(String[] args) throws IOException {
+		Scanner sc = new Scanner(System.in);		
+		int testCase = sc.nextInt();
+		long [] dp = new long [101];
+		dp[0] = 0;
+		dp[1] = 1;
+		dp[2] = 1;
+		for(int i=3; i<101; i++) {
+			dp[i] = dp[i-3] + dp[i-2];
+		}		
+		for(int i=0; i<testCase; i++) {			
+			int n = sc.nextInt();	
+			
+			System.out.println(dp[n]);			
+		}
+		sc.close();
+		
+	}
+
+}


### PR DESCRIPTION
## :+1:  문제 접근

처음엔 그림을 보고 dp의 점화식을 세웠는데 
> dp(n)  =  dp(n-1) + dp(n-5)

문제를 풀다가 수의 나열을 보니 다음 점화식도 가능한 것을 발견했습니다.
>  dp(n)  =  dp(n-2) + dp(n-3)

## :-1: 반성할 점

아무 생각 없이 dp 배열을 **int**로 설정한 것이 아쉬웠습니다.
int가 대략  _2,000,000,000_ 정도 조금 넘어서 까지 저장 가능하고,

int로 만든상태로 해당 프로그램의 입력을 78정도까지 넣어봤을 때
_1,828,587,033_ 이 숫자가 나오는 것을 보고 100 까지 감당하려면 **long**으로 배열을 만들어야 하는 것을 알 수 있습니다.

이런 사소한 자료형이나 숫자의 범위에 주의할 필요성을 느꼈습니다.

