### PR TITLE
임준규 : BOJ 1260 BFSDFS

### DIFF
--- a/Junkyu_Lim/Week3/1260_bfsdfs.java
+++ b/Junkyu_Lim/Week3/1260_bfsdfs.java
@@ -1,0 +1,61 @@
+import java.util.*;
+import java.io.*;
+
+public class bfsdfs {
+    public static boolean[] visited;
+    public static boolean[][] graph;
+    public static StringJoiner sj;
+
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt( st.nextToken());
+        int V = Integer.parseInt( st.nextToken());
+
+        visited = new boolean[N+1];
+        graph = new boolean[N+1][N+1];
+
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine(), " ");
+            int x = Integer.parseInt(st.nextToken());
+            int y = Integer.parseInt( st.nextToken());
+            graph[x][y] = true;
+            graph[y][x] = true;
+        }
+        sj = new StringJoiner(" ");
+        DFS(V);
+        System.out.println(sj.toString());
+
+        sj = new StringJoiner(" ");
+        visited = new boolean[N+1];
+        BFS(V);
+        System.out.println(sj.toString());
+    }
+
+    private static void DFS(int start){
+        visited[start] = true;
+        sj.add(Integer.toString(start));
+        for(int i = 1; i < graph.length; i++){
+            if(!visited[i] && graph[start][i]) DFS(i);
+        }
+    }
+
+    private static void BFS(int start){
+        Queue<Integer> que = new LinkedList<>();
+        que.add(start);
+        visited[start] = true;
+
+        while(!que.isEmpty()){
+            int target = que.poll();
+            sj.add(Integer.toString(target));
+            for(int i = 1; i < graph.length; i++){
+                if(!visited[i] && graph[target][i]){
+                    que.add(i);
+                    visited[i] = true;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 설계
이름부터 뭘 써야할 지 알려주는 문제였기 때문에, 설계는 어렵지 않았다.
완료 후 문자열 처리가 고민이 되었는데, StringJoiner을 통해서 어렵지 않게 해결했다.
StringBuilder와 다른 점은 append가 아닌 add을 쓴다는 점이 있다.
ide없이 하니까 위의 사항에서 애를 좀 먹었다. ide가 그리운 순간이었다.

## 코드
메인 함수의 입력부분은 뛰어넘겠다.
```
sj = new StringJoiner(" ");
DFS(V);
System.out.println(sj.toString());

sj = new StringJoiner(" ");
visited = new boolean[N+1];
BFS(V);
System.out.println(sj.toString());
```
입력을 마치고 다음과 같이 stringjoiner와 visited를 초기화하며 사용하였다.

```
private static void DFS(int start){
        visited[start] = true;
        sj.add(Integer.toString(start));
        for(int i = 1; i < graph.length; i++){
            if(!visited[i] && graph[start][i]) DFS(i);
        }
    }
```
개인적으로 구현이 보다 쉽다고 느꼈던 DFS이다.
재귀를 통해서 재귀를 시작할 때 마다 방문을 했다고 체크하고, 노드에 연결된 노드를 찾아서 재귀한다.

```
private static void BFS(int start){
        Queue<Integer> que = new LinkedList<>();
        que.add(start);
        visited[start] = true;

        while(!que.isEmpty()){
            int target = que.poll();
            sj.add(Integer.toString(target));
            for(int i = 1; i < graph.length; i++){
                if(!visited[i] && graph[target][i]){
                    que.add(i);
                    visited[i] = true;
                }
            }
        }
    }
```
항상 *FS문제를 풀 때, 고민되는 점은 visited의 시점인 것 같습니다.
for문을 반복하며 큐에 들어가게 된 후에는 다른 노드에서 큐에 들어가면 안되므로 큐에 넣은 직후에 마킹을 해주었습니다.
연결이 되어있는 모든 노드를 반복하므로 `while(!que.isEmpty())`조건으로 한정이 가능합니다.