### PR TITLE
황종훈 : BOJ 1300 K번째 수

### DIFF
--- a/HwangJongHoon/BOJ/Week4/Exam1300_K번째수.java
+++ b/HwangJongHoon/BOJ/Week4/Exam1300_K번째수.java
@@ -1,0 +1,37 @@
+package Baekjoon.BinarySearch;
+
+import java.io.IOException;
+import java.util.Scanner;
+
+public class Exam1300_K번째수 {
+    public static void main(String[] args) throws IOException {
+        Scanner sc = new Scanner(System.in);
+
+        int N = sc.nextInt();
+        int K = sc.nextInt();
+        long result = 0;
+
+        // A[i][j] = i * j인 2차원 배열을 1차원 배열 B로 만들고 오름차순으로 정렬했을때,
+        // B[k]를 구하라. 단 A와 B의 인덱스는 1부터 시작한다.
+
+        long start = 1;
+        long end = K;
+        long mid = 0;
+        while(start <= end){
+            long cnt = 0;
+            mid = (start + end) / 2;
+            for(int i = 1; i <= N; ++i){
+                cnt += Math.min(mid / i, N);
+            }
+            if(cnt >= K){
+                result = mid;
+                end = mid - 1;
+            } else {
+                start = mid + 1;
+            }
+        }
+
+        System.out.println(result);
+        sc.close();
+    }
+}


### PR DESCRIPTION
# BOJ 1300번 K번째 수

## 🛠설계

N(1 <= N <= 10<sup>5</sup>)과 K(1 <= K <= min(N<sup>2</sup>,10<sup>9</sup>))가 주어지면

A[i][j] = i * j인 2차원 배열을 1차원 배열 B로 만들고 오름차순으로 정렬했을때, B[K]를 구하는 문제입니다.

우선 N의 최대값인 10<sup>5</sup> = 100,000을 가정해서 2차원 배열 A로 만들고 다시 이것을 1차원 배열 B로 바꿔주면

**무려 크기가 100,000,000,000이 되기 때문에 자료를 만들어 탐색하는 것은 불가능**합니다.

그래서 배열 B가 만들어졌을때의 규칙을 파악하고 풀어야 하는데, 아무리 생각해도 떠오르지 않아서 다른 풀이를 참고해서 풀었습니다.

## 💻 코드

### 
```.java
        Scanner sc = new Scanner(System.in);

        int N = sc.nextInt();
        int K = sc.nextInt();
        long result = 0;

        // A[i][j] = i * j인 2차원 배열을 1차원 배열 B로 만들고 오름차순으로 정렬했을때,
        // B[k]를 구하라. 단 A와 B의 인덱스는 1부터 시작한다.

        long start = 1;
        long end = K;
        long mid = 0;
        while(start <= end){
            long cnt = 0;
            mid = (start + end) / 2;
            for(int i = 1; i <= N; ++i){
                cnt += Math.min(mid / i, N); // 이 문제의 핵심
            }
            if(cnt >= K){
                result = mid;
                end = mid - 1;
            } else {
                start = mid + 1;
            }
        }

        System.out.println(result);
        sc.close();
```

코드 진짜 간단하죠? 아시다 싶이 이런 문제가 훨씬 어렵습니다.. ㅠㅠ

이 문제의 핵심은 **1부터 N까지 루프를 반복하며 cnt에 `Math.min(mid / i, N)`를 더해주는 부분**입니다.

**`mid / i`는 b[K]가 2차원 배열 A일 때, i 행에서 존재할 수 있는 열**입니다. 

하지만 A는 N * N 배열이라 열도 N을 넘어갈 수 없죠. 그래서 mid / i가 N보다 커지면 cnt에 N을 더해주는 겁니다.

그렇게 행마다 계산하여 cnt에 전부 더하고 루프를 빠져 나오면 K와 비교해줘서 이분 탐색을 진행합니다.

이분 탐색 부분은 평범해서 별다른 코멘트를 달 곳이 없습니다.

다만 저는 처음에 `if(cnt >= K)` 조건문일때 mid를 저장하지 않고 그대로 출력해서 틀렸었는데 이 부분도 꽤 중요한 것 같네요.

**cnt는 꼭 K와 같거나 커야하고 그보다 절대 작을 수는 없기에 mid를 꼭 저장해 줘야 합니다**.

시간 복잡도는 이진탐색 안에 N번 반복하는 루프가 들어가 있기 때문에 **nlogn** 정도 되겠네요.

## 📝 후기
Key가 되는 식 하나만 세우면 놀라울 정도로 쉽게 풀립니다. 다만 그 식까지 도달하기가 너무 어렵다는게,,,, 문제지요,,,