### PR TITLE
임인호 : BOJ 14888 연산자 끼워넣기

### DIFF
--- a/Inho/BOJ/Week5/Boj14888_연산자끼워넣기.java
+++ b/Inho/BOJ/Week5/Boj14888_연산자끼워넣기.java
@@ -1,0 +1,75 @@
+package Study_Algorithm_Team_2.Inho.BOJ.Week5;
+import java.util.*;
+import java.io.*;
+class Boj14888{
+    static int n;
+    static int [] arr;
+    static int [] operatorCount;
+    static int [] operator;
+    static int min;
+    static int max;
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        
+        n = Integer.parseInt(br.readLine());
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        arr = new int [n];
+        operatorCount = new int [4];
+        operator = new int [n -1];
+        min = Integer.MAX_VALUE;
+        max = Integer.MIN_VALUE;
+
+        for(int i=0; i<n; i++){
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+        st = new StringTokenizer(br.readLine());
+        for(int i=0; i<4; i++){
+            operatorCount[i] = Integer.parseInt(st.nextToken());
+        }
+
+        dfs(0);
+        bw.write(max +"\n");
+        bw.write(min + "\n");
+        br.close();
+        bw.flush();
+        bw.close();
+    }
+    public static void dfs(int count) throws IOException{
+        if(count == n-1){
+            int result = calculate();
+            min = Math.min(min, result);
+            max = Math.max(max, result);
+            return;
+        }
+        for(int i=0; i<4; i++){
+            if(operatorCount[i] > 0){
+                operatorCount[i]--;
+                operator[count] = i;
+                dfs(count + 1);
+                operatorCount[i]++;
+            }
+        }
+
+    }
+    public static int calculate(){
+        int result = arr[0];
+        for(int i=0; i<n-1; i++){
+            switch (operator[i]){
+                case 0:
+                    result += arr[i+1];
+                    break;
+                case 1:
+                    result -= arr[i+1];
+                    break;
+                case 2:
+                    result *= arr[i+1];
+                    break;
+                case 3:
+                    result /= arr[i+1];
+                    break;
+            }
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
# 👍 문제 접근
수열과 연산자의 종류별 개수가 주어집니다.
수열은 바꾸지 않고 연산자들의 조합을 찾아 계산값의 최소 최대를 찾는 문제입니다.

이 문제 역시 스타트와 링크 문제처럼 조합을 찾아 모든 경우를 계산하는 문제라 **백트래킹**을 사용했습니다.

먼저 주어진 수열은 arr 배열에,
연산자 종류별 갯수는 opertorCount 배열에 저장합니다.

dfs함수는 다음과 같습니다. 백트래킹 답게 count를 인자로 끌고가며, 트리의 가장 마지막 노드에 도달했을 때 계산을 해 최소, 최대값을 갱신합니다. 수열 수는 n개 이지만, 연산자 개수는 n-1임에 주의합니다.
```
public static void dfs(int count) throws IOException{
    if(count == n-1){
        int result = calculate();
        min = Math.min(min, result);
        max = Math.max(max, result);
        return;
    }
    for(int i=0; i<4; i++){
        if(operatorCount[i] > 0){
            operatorCount[i]--;
            operator[count] = i;
            dfs(count + 1);
            operatorCount[i]++;
        }
    }
}
```

operatorCount에는 + - * / 가 순서대로 몇개씩 있는지 저장됩니다.
따라서 인덱스 0은 +, 1은 - ,,,, 이런식으로 진행됩니다.
dfs로 탐색할 때, 이 조건에 맞춰서 for문을 돌립니다. 
해당 인덱스의 연산자가 존재하면, 연산자를 사용한다고 가정해 해당 인덱스의 값을 감소시키고 operator배열에 연산자의 인덱스를 집어넣습니다.
dfs로 탐색시키고, 이후 다른 경우를 위해 감소시킨 것을 원상복구 합니다.

count 가 n-1이면 연산자들이 모여 하나의 식이 완성됩니다. 이때 calculate를 통해 계산합니다.
```
public static int calculate(){
    int result = arr[0];
    for(int i=0; i<n-1; i++){
        switch (operator[i]){
            case 0:
                result += arr[i+1];
                break;
            case 1:
                result -= arr[i+1];
                break;
            case 2:
                result *= arr[i+1];
                break;
            case 3:
                result /= arr[i+1];
                break;
        }
    }
    return result;
}
```

# 👎 반성할 점
코멘트 쓰면서 다시 보니 최대 최소값은 calculate함수 내에서 갱신하는 게 더 깔끔해 보이네요.
dfs에서 다른 경우를 탐색하는 방식을 생각해 내는게 포인트인 문제같습니다. 백트래킹과 dfs는 가지가 뻗어나가는 그림을 머릿속에서 그리면 도움이 된다고 합니다.
지난주 문제가 추상적으로 느껴져서 어려웠는데, 이번 문제는 그렇지 않아 재미있었습니다. 
이말은 제가 이분탐색을 더 공부해야 한다는 말이되겠네요..😂