### PR TITLE
임인호 : Programmers3 경주로건설(수정)

### DIFF
--- a/Inho/Programmers/Week3/Programmers3_경주로건설2.java
+++ b/Inho/Programmers/Week3/Programmers3_경주로건설2.java
@@ -1,0 +1,57 @@
+import java.util.*;
+import java.io.*;
+class Solution {
+    public int solution(int[][] board) {
+        int n = board.length;
+        
+        int [][][] cost = new int [n][n][4];
+        int [] dx = {1, 0, -1, 0};
+        int [] dy = {0, -1, 0, 1};
+        
+        for(int i=0; i<n; i++){
+            for(int j=0; j<n; j++){
+                for(int k=0; k<4; k++){
+                    cost[i][j][k] = Integer.MAX_VALUE;
+                }
+            }
+        }
+        
+        
+        Queue<int []> queue = new LinkedList<int []>();
+        int [] start = {0, 0, -1, 0};
+        queue.offer(start);
+        
+        while(!queue.isEmpty()){
+            int [] tmp = queue.poll();
+            int x = tmp[0];
+            int y = tmp[1];
+            int dir = tmp[2];
+            int sum = tmp[3];
+            
+            for(int i=0; i<4; i++){
+                int nx = x + dx[i];
+                int ny = y + dy[i];
+                
+                if(nx < 0 || ny < 0 || nx >= n || ny >= n || board[nx][ny] == 1){
+                    continue;
+                }
+                //내가 계산된 값이 뻗어나갈 그 곳의 기존 값보다 작으면 추가
+                int newCost = sum;
+                if(dir == i || dir == -1){
+                    newCost += 100;
+                }else{
+                    newCost += 600;
+                }
+                if(newCost <= cost[nx][ny][i]){
+                    cost[nx][ny][i] = newCost;
+                    queue.offer(new int [] {nx, ny, i, newCost});
+                }
+            }
+        }
+        int answer = Integer.MAX_VALUE;
+        for(int i=0; i<4; i++){
+            answer = Math.min(answer, cost[n-1][n-1][i]);
+        }
+        return answer;
+    }
+}


### PR DESCRIPTION
# 🚧  경주로 건설 문제 접근
> 죠르디 혐오를 불러일으켰던 화제의 그 문제입니다. 더 독해져서 돌아왔어요..

아래는 기존 코드입니다.

```java
public static int solution(int[][] board) {
    int n = board.length;
    
    int [] dx = {0, 1, 0, -1};
    int [] dy = {1, 0, -1, 0};
    
    Queue<int []> queue = new LinkedList<int []>();

    // 처음에는 이전 방향이 없으므로 예외를 위해 -1로 설정합니다.
    int [] start = {0, 0, -1, 0};
    queue.offer(start);
    
    while(!queue.isEmpty()){
        int [] tmp = queue.poll();
        int x = tmp[0];
        int y = tmp[1];
        int dir = tmp[2];
        int cost = tmp[3];
        
        for(int i=0; i<4; i++){
            int nx = x + dx[i];
            int ny = y + dy[i];
            
            if(nx < 0 || ny < 0 || nx >= n || ny >= n || board[nx][ny] == 1){
                continue;
            }
            //내가 계산된 값이 뻗어나갈 그 곳의 기존 값(dp)보다 작으면 추가
        
            int newCost = cost;
            if(dir == i || dir == -1){
                newCost += 100;
            }else{
                newCost += 600;
            }
            if(board[nx][ny] == 0 || newCost <= board[nx][ny]){
                board[nx][ny] = newCost;
                queue.offer(new int [] {nx, ny, i, newCost});
            }
        }
    }
    return board[n-1][n-1];
}
```

새로운 테스트케이스가 뭘까 헤매다가, 질문하기 탭의 도움을 받아 찾았습니다.

0 0 0 0 0
0 1  1  1 0
0 0  1 0 0
1  0 0 0 1
0 1  1 0 0

이 경우입니다.
 
위와 같은 맵은 크게 오른쪽 루트와 왼쪽 루트로 나뉩니다.
두 루트는 3,3 지점에서 만나게 됩니다. 여기서 문제가 발생합니다. 
경로상 왼쪽 루트가 더 빠르게 3,3 에 도달하는데 이때까지의 건설 비용 은 **2100** 입니다.
이후 오른쪽 루트도 3,3 에 도달하는데 이 루트의 건설비용은 **2300** 입니다. 
오른쪽 루트의 건설비용이 이전 dp값으로 메모이제이션 된 2100 보다 크므로 탐색을 포기합니다.

### 반전은
사실 오른쪽 루트로 가는게 최종 목적지에서는 더 건설비용이 저렴합니다. 이후는 3,3 -> 4,3 -> 4,4(도착) 으로 두 루트 모두 경로가 같은데
왼쪽루트는 방향때문에 이후에 **코너가 2번**이고, 오른쪽 루트는 **코너가 한번** 이 됩니다.
메모이제이션 방식 자체가 잘못 된 것을 의미하져..

저는 이걸 모르고 dfs로도 풀어보고 별짓을 다했습니다. 심지어 dfs는 한번에 도착점까지 가므로 해당 예시에서도 dx, dy의 방향이 오른쪽부터 먼저 탐색하게 하면 새로운 예외 테스트케이스를 통과합니다. (이걸 모르고 처음에는 맞았다고 좋아했네요ㅋㅋ) 
헤매다가 제가 이전에 이 문제로 올린 PR을 봤습니다. 거기에 제가 이렇게 써놨더라구요

> 이 두 경우는 방향에 따라 누적 가격이 다르므로 꼭 큐에서 방향과 함께 가지고 있어야 합니다.

그때 저는 큐에 매 경로의 누적 가격을 안끌고 다니고, dp 값으로만 다 대체를 해서 틀렸었습니다. 그리고 지금 문제도 비슷하다는걸 알아냈습니다.
그냥 각 칸의 메모이제이션을 방향별로 따로 저장해두면 해결될 문제였습니다.

이전에는 board에 그대로 메모이제이션 했지만, 이제는 방향 차원까지 필요하므로 새 3차원 배열을 만들어줍니다.
최솟값으로 메모이제이션 할거니까 최댓값으로 몽땅 초기화해줍니다.

```java
int [][][] cost = new int [n][n][4];
        
for(int i=0; i<n; i++){
    for(int j=0; j<n; j++){
        for(int k=0; k<4; k++){
            cost[i][j][k] = Integer.MAX_VALUE;
        }
    }
}
```

이후 큐 안에서 dp값과 새 경로값을 비교할 때, 방향별로 비교해줍니다. 여기서 i는 nx, ny가 가지는 다음 방향을 나타냅니다.
```java
if(newCost <= cost[nx][ny][i]){
    cost[nx][ny][i] = newCost;
    queue.offer(new int [] {nx, ny, i, newCost});
}
```

원래 코드에서는 dp배열의 n-1, n-1 칸만 반환하면 되었지만, 이제는 도착값의 최솟값들이 방향별로 따로 존재합니다.
따라서 4방향중 가장 작은값을 반환합니다.
```java
int answer = Integer.MAX_VALUE;
for(int i=0; i<4; i++){
    answer = Math.min(answer, cost[n-1][n-1][i]);
}
return answer;
```

아까 예시를 다시 보자면
왼쪽 루트로 3,3 좌표 dp배열에 왼쪽에서 오는 방향으로 2100 이 저장되고, 
오른쪽 루트에서 3,3에 올때는  dp배열에 위쪽에서 오는방향으로 별도로 2300 이 저장됩니다. 
이후 두 루트 모두 계속 탐색을 하고 마지막 칸에서 각각 3300, 3000 값을 가집니다. 따라서 3,3에서는 컷지만 마지막 칸에서 가장 작은 오른쪽 루트가 최종 답이 됩니다.

# 🥲 아쉬운 점
글쎄요,,, 문제가 아쉽진 않고 제 실력이 아쉽네요. 
웃긴건 카카오 공식 해설에서는 완전 다른소리를 하고있다는겁니다. 

제 풀이가 일단은 맞지만, 저 해설에 따르면 출제의도에서 벗어난 풀이가 되겠네요. 프로그래머스에서 다른 분들의 제출 내역을 보면서
공식 해설처럼 푼 코드를 찾아보려 했으나 찾지 못했습니다. 혹시 구현하실 의향이 있다면 환영합니다!

별거 아닌데 하루종일 고생한거라 길게 쓰고싶었나봅니다. 여담으로 궁금한건 이런 문제는 누가 내는걸까요? 지금처럼 오류..? 까지는 아니여도 테스트케이스 부실이면 책임이 누구에게 가는지도 궁금해지네요ㅋㅋ

아래는 공식 해설 발췌입니다
----
### 문제 해설
최단 경로를 구하기 위해 BFS를 이용하여 살펴 보겠습니다. 먼저 출발지 → 도착지로 이동하는 [코너가 1개인 경로, 코너가 2개인 경로, 코너가 3개인 경로, …, 코너가 K개인 경로] 중 가장 적은 비용이 드는 경로를 찾습니다. 예를 들어 예제 1번 [[0,0,0],[0,0,0],[0,0,0]]의 경우 코너가 1개이면서 가장 적은 비용이 드는 경로는 다음과 같이 2 가지입니다.

(0,0) → (0,1) → (0,2) → (1,2) → (2,2)
(0,0) → (1,0) → (2,0) → (2,1) → (2,2)
코너가 2개이면서 가장 적은 비용이 드는 경로 중 하나는 다음과 같습니다.

(0,0) → (0,1) → (1,1) → (2,1) → (2,2)
이 외에도 다양한 경로가 있으며, 코너가 K개일 때 가장 적은 비용이 들려면 직선 도로 개수를 최대한 줄이면 됩니다. 이는 코너를 K개 만들면서 출발지에서 도착지까지 가는 최단 경로를 찾으면 됩니다.

이제 다음과 같이 상태 공간 S를 정의합니다.

S = [세로 좌표 R][가로 좌표 C][코너 개수 K][바라보는 방향 D] → 코너 K개를 만들면서 (R, C) 위치에 도착했고, D방향을 바라보고 있을 때의 최단 거리
이때 한 칸 이동하는데 드는 비용은 1, 코너를 하나 만드는 비용도 1이라고 가정합니다. 이제 출발지 → 도착지로 이동하는 최단 경로를 모든 K에 대해서 찾아줍니다. BFS 탐색 코드는 다음과 같이 작성합니다.

마지막으로 바라본 방향을 기준으로 왼쪽 회전, 오른쪽 회전, 직진 하는 3가지 경우에 대해 탐색합니다.
왼쪽 회전, 오른쪽 회전의 경우 코너를 하나 추가하고, 바라보는 방향을 바꿔줍니다.
직진의 경우 바라보는 방향으로 1칸 전진합니다.
위와 같이 BFS 탐색을 한 후, 마지막으로 (N – 1, N – 1) 위치에서 K = 1, 2, 3, … 인 경우에 대해 최단 거리를 찾아주면 됩니다. 이때, 주의 할 점은 여기서 구한 최단 거리는 코너 개수가 포함된 값이라는 것입니다. 따라서 코너가 K개인 최단 거리에서 건설 비용은 다음과 같이 계산하면 됩니다.

(최단 거리 – K) x 100 + K * 500
그렇다면 여기서 K값은 얼마나 커질 수 있을까요? 각 격자칸 하나에는 코너가 최대 1개 생길 수 있습니다. 그렇다면 N x N 크기 격자에서 코너 개수는 격자칸 개수보다는 작아야 합니다. 따라서 코너 개수 K는 최대 N x N이면 됩니다.


