### PR TITLE
임준규 : Programmers 17676 추석 트래픽

### DIFF
--- a/Junkyu_Lim/Week22/17676.java
+++ b/Junkyu_Lim/Week22/17676.java
@@ -1,0 +1,62 @@
+import java.util.*;
+
+class Solution {
+    public int solution(String[] lines) {
+        ArrayList<Log> logs = new ArrayList<>();
+        int answer = 0;
+        
+        for(String line : lines) {
+            logs.add(getLog(line));
+        }
+        
+        for(Log log : logs) {
+            int sCount = 0;
+            int eCount = 0;
+            
+            for (Log iLog : logs) {
+                if (log.startTime <= iLog.endTime && iLog.startTime <= log.startTime + 999)
+                    sCount ++;
+                
+                if (log.endTime <= iLog.endTime && iLog.startTime <= log.endTime + 999)
+                    eCount ++;
+            }
+            
+            answer = Math.max(Math.max(sCount, eCount), answer);
+        }
+        
+        return answer;
+    }
+    
+    private Log getLog(String line) {
+        String[] splitLine = line.split(" ");
+        
+        String[] responseTimes = splitLine[1].split(":");
+        int handleTime = (int)(Double.parseDouble(splitLine[2].replace("s", "")) * 1000);
+
+        int endTime = 0;
+        int startTime = 0;
+        
+        endTime += 3600 * 1000 * Integer.parseInt(responseTimes[0]);
+        endTime += 60 * 1000  * Integer.parseInt(responseTimes[1]);
+        endTime += (int)(Double.parseDouble(responseTimes[2]) * 1000);
+
+        startTime = endTime - handleTime + 1;
+
+        return new Log(startTime, endTime);
+    }
+}
+
+class Log {
+    int startTime;
+    int endTime;
+    
+    public Log(int s, int e) {
+        this.startTime = s;
+        this.endTime = e;
+    }
+    
+    @Override
+    public String toString(){
+        return "s : " + startTime + " / e : " + endTime;
+    }
+}


### PR DESCRIPTION
## ⚒설계
처음에는 셔틀버스나 방금그곡(?)과 같은 식으로 접근을 하려 했습니다. 
하지만 이번 문제는 1초 동안 몇개의 로그가 처리되었는지 카운트를 구해야해서 비슷하게 풀기는 어려운 부분이었습니다.
다음으로는 1마이크로초씩 슬라이딩 윈도우를 통해서 구해주는 방식을 생각해봤었습니다.
log 전체 탐색을 86,400,000회 반복을 해야하는데, 연산에 문제가 발생하리라 생각이 들어서 이것도 포기했습니다.

그리고 다시 생각해봤을 때, 카운트가 바뀔만한 부분은 시작할 때, 그리고 끝날 떄 이렇게 두번 발생할 것이라고 생각했습니다.
그래서 처리 시작과 끝에서 각각 1초씩 체크해줘서 처리량을 구해주었습니다.

## 💻 코드
```.java
private Log getLog(String line) {
    String[] splitLine = line.split(" ");
    
    String[] responseTimes = splitLine[1].split(":");
    int handleTime = (int)(Double.parseDouble(splitLine[2].replace("s", "")) * 1000);

    int endTime = 0;
    int startTime = 0;
    
    endTime += 3600 * 1000 * Integer.parseInt(responseTimes[0]);
    endTime += 60 * 1000  * Integer.parseInt(responseTimes[1]);
    endTime += (int)(Double.parseDouble(responseTimes[2]) * 1000);

    startTime = endTime - handleTime + 1;

    return new Log(startTime, endTime);
}
```
line을 시작시간과 끝시간을 저장하고 있는 log로 바꾸어주는 함수입니다.
날짜는 쓸데가 없어서 버려주었고, 연산의 용이성을 위하여 1000씩 곱해서 int로 사용해주었습니다.
startTime은 예제처럼 handleTime을 빼주고, 1을 더해주었습니다.

```.java
for(Log log : logs) {
    int sCount = 0;
    int eCount = 0;
    
    for (Log iLog : logs) {
        if (log.startTime <= iLog.endTime && iLog.startTime <= log.startTime + 999)
            sCount ++;
        
        if (log.endTime <= iLog.endTime && iLog.startTime <= log.endTime + 999)
            eCount ++;
    }
    
    answer = Math.max(Math.max(sCount, eCount), answer);
}
```
log를 순회하면서 정답을 찾아주는 함수입니다.
이중 for문을 통해서 찾아주었습니다.

바깥의 for문은 log하나를 진행하면서 잡아주었고, 내부의 for문은 비교할 log를 찾아주어서 로그의 시작, 끝시간 1초 내에 있으면 카운트를 기록해주었습니다.

결과값으로 answer와 시작카운트 끝카운트를 비교하여 가장 큰 값을 answer로 갱신해주었습니다.